### PR TITLE
implement serialization of board and gamestate into FEN with testing.…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "console_log"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501a375961cef1a0d44767200e66e4a559283097e91d0730b1d75dfb2f8a1494"
+checksum = "878ad067d4089144a36ee412d665916c665430eb84c0057b9987f424a5d15c03"
 dependencies = [
  "log",
  "wasm-bindgen",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1648,9 +1648,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/chess_engine/src/castle_perm.rs
+++ b/chess_engine/src/castle_perm.rs
@@ -81,6 +81,31 @@ impl CastlePerm {
             }),
         }
     }
+
+    pub fn to_castle_perm_fen(&self) -> String {
+        let mut castle_perms_fen = String::with_capacity(MAX_CASTLE_PERM_FEN_LEN);
+        for perm in self.0.into_iter().flatten() {
+            match perm.to_string().as_str() {
+                "WhiteKing" => {
+                    castle_perms_fen.push('K');
+                }
+                "WhiteQueen" => castle_perms_fen.push('Q'),
+                "BlackKing" => {
+                    castle_perms_fen.push('k');
+                }
+                "BlackQueen" => {
+                    castle_perms_fen.push('q');
+                }
+                _ => {
+                    panic!()
+                }
+            }
+        }
+        match castle_perms_fen.len() {
+            0 => "-".to_owned(),
+            _ => castle_perms_fen,
+        }
+    }
 }
 
 impl From<CastlePerm> for u8 {
@@ -124,28 +149,7 @@ impl TryFrom<&str> for CastlePerm {
 /// Display in FEN style
 impl fmt::Display for CastlePerm {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut castle_perms_fen = String::with_capacity(MAX_CASTLE_PERM_FEN_LEN);
-        for perm in self.0.into_iter().flatten() {
-            match perm.to_string().as_str() {
-                "WhiteKing" => {
-                    castle_perms_fen.push('K');
-                }
-                "WhiteQueen" => castle_perms_fen.push('Q'),
-                "BlackKing" => {
-                    castle_perms_fen.push('k');
-                }
-                "BlackQueen" => {
-                    castle_perms_fen.push('q');
-                }
-                _ => {
-                    panic!()
-                }
-            }
-        }
-        match castle_perms_fen.len() {
-            0 => write!(f, "-"),
-            _ => write!(f, "{}", castle_perms_fen.as_str()),
-        }
+        write!(f, "{}", self.to_castle_perm_fen().as_str())
     }
 }
 

--- a/chess_engine/src/error.rs
+++ b/chess_engine/src/error.rs
@@ -146,6 +146,9 @@ pub enum GamestateBuildError {
 
 #[derive(Error, Debug, PartialEq)]
 pub enum GamestateValidityCheckError {
+    #[error("Board is invalid")]
+    BoardValidityCheck(#[from] BoardValidityCheckError),
+
     #[error("En passant square exists so the halfmove clock: {halfmove_clock} should be 0")]
     StrictEnPassantHalfmoveClockNotZero { halfmove_clock: u8 },
 

--- a/chess_engine/src/square.rs
+++ b/chess_engine/src/square.rs
@@ -103,6 +103,7 @@ impl TryFrom<usize> for Square64 {
             .find(|s| *s as usize == value)
             .ok_or(Square64ConversionError::FromUsize { index: value })
     }
+
 }
 
 impl Square64 {


### PR DESCRIPTION
… Change gamestate_check and board_check functions to not consume Board/Gamestate. This way it can be used outside of just building. Change how new_with_fen works for both Board and Gamestate so that you can build invalid gamestates from a fen (before the strict check was run automatically on board). This will be useful for testing, and could be useful for board editing and anything else that requires an invalid state that might eventually become valid