### PR TITLE
Iterations on Builder and Move setup

### DIFF
--- a/chess_engine/src/board.rs
+++ b/chess_engine/src/board.rs
@@ -3,8 +3,7 @@ pub mod bitboard;
 use crate::{
     color::Color,
     error::{
-        BoardBuildError, BoardFenDeserializeError , BoardValidityCheckError,
-        RankFenDeserializeError,
+        BoardBuildError, BoardFenDeserializeError, BoardValidityCheckError, RankFenDeserializeError,
     },
     file::File,
     gamestate::ValidityCheck,

--- a/chess_engine/src/board.rs
+++ b/chess_engine/src/board.rs
@@ -279,8 +279,7 @@ impl Default for BoardBuilder {
     }
 }
 
-// TODO: consider deriving copy to make Gamestate reusable
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Board {
     // TODO: Consider making board field private
     pub pieces: [Option<Piece>; NUM_BOARD_SQUARES],

--- a/chess_engine/src/board.rs
+++ b/chess_engine/src/board.rs
@@ -58,7 +58,6 @@ impl BoardBuilder {
 
     /// Constructor if you want to pass piece values all at once (you can still overwrite them later)
     pub fn new_with_pieces(pieces: [Option<Piece>; NUM_BOARD_SQUARES]) -> Self {
-        // generate board fen that corresponds to pieces
         BoardBuilder {
             validity_check: ValidityCheck::Strict,
             pieces,
@@ -98,7 +97,8 @@ impl BoardBuilder {
         let mut minor_piece_count: [u8; Color::COUNT] = [0; Color::COUNT];
         let mut piece_list: [Vec<Square>; Piece::COUNT] = Default::default();
 
-        // Note: pieces are being cloned here. Optimizer might elide clones/copies if you
+        // Note: pieces are being cloned here so that we can create multiple boards.
+        // from the same builder. Optimizer might elide clones/copies if you
         // don't reuse the BoardBuilder, but not sure.
         let pieces = self.pieces;
 
@@ -279,6 +279,7 @@ impl Default for BoardBuilder {
     }
 }
 
+// TODO: consider deriving copy to make Gamestate reusable
 #[derive(Debug, PartialEq, Eq)]
 pub struct Board {
     // TODO: Consider making board field private
@@ -852,11 +853,24 @@ mod tests {
             .piece(Piece::WhiteKing, Square64::D1)
             .piece(Piece::WhiteKnight, Square64::B1)
             .piece(Piece::WhiteKnight, Square64::C1)
-            .piece(Piece::WhiteKnight, Square64::G1);
+            .piece(Piece::WhiteKnight, Square64::G1)
+            .piece(Piece::BlackKing, Square64::D8);
 
         for i in 8_u8..=15 {
             output.piece(Piece::WhitePawn, Square64::try_from(i).unwrap());
         }
+
+        let output = output.build();
+        let expected = Err(BoardBuildError::BoardValidityCheck(
+            BoardValidityCheckError::StrictMoreExcessBigPiecesThanMissingPawns {
+                num_excess_big_pieces_white: 1,
+                num_missing_pawns_white: 0,
+                num_excess_big_pieces_black: 0,
+                num_missing_pawns_black: 8
+            }
+        ));
+
+        assert_eq!(output, expected);
     }
 
     #[test]

--- a/chess_engine/src/board/bitboard.rs
+++ b/chess_engine/src/board/bitboard.rs
@@ -40,15 +40,19 @@ pub struct BitBoard(pub u64);
 impl BitBoard {
     /// Counts number of set bits
     pub fn count_bits(&self) -> u8 {
-        let mut count: u8 = 0;
-        let mut b = self.0;
-        while b > 0 {
-            count += 1;
-            // converts the current least significant 1 into 0111... with the -1
-            // then removes trailing 1s into 0s with the & (1000 & 0111 = 0000)
-            b &= b - 1;
-        }
-        count
+        // NOTE: not sure how count_ones is implemented, but these are some useful resources
+        // divide and conquer: https://www.youtube.com/watch?v=ZusiKXcz_ac
+        // https://arxiv.org/pdf/1611.07612.pdf
+        self.0.count_ones() as u8
+        // let mut count: u8 = 0;
+        // let mut b = self.0;
+        // while b > 0 {
+        //     count += 1;
+        //     // converts the current least significant 1 into 0111... with the -1
+        //     // then removes trailing 1s into 0s with the & (1000 & 0111 = 0000)
+        //     b &= b - 1;
+        // }
+        // count
     }
 
     /// Sets the first set LSB to 0 and returns the index corresponding to it

--- a/chess_engine/src/error.rs
+++ b/chess_engine/src/error.rs
@@ -21,6 +21,21 @@ pub enum ChessError {
 }
 
 #[derive(Error, Debug, PartialEq)]
+pub enum MoveDeserializeError {
+    #[error("The start square {start} is invalid for move:\n {_move}")]
+    Start { start: u32, _move: String },
+
+    #[error("The end square {end} is invalid for move:\n {_move}")]
+    End { end: u32, _move: String },
+
+    #[error("The captured piece {piece} is invalid for move:\n {_move}")]
+    Captured { piece: u32, _move: String },
+
+    #[error("The promoted piece {piece} is invalid for move:\n {_move}")]
+    Promoted { piece: u32, _move: String },
+}
+
+#[derive(Error, Debug, PartialEq)]
 pub enum RankFenDeserializeError {
     #[error("Failed to deserialize pieces of rank from rank fen due to invalid char")]
     InvalidChar(#[from] PieceConversionError),
@@ -249,6 +264,9 @@ pub enum PieceConversionError {
 
     #[error("could not convert usize {invalid_usize} into a Piece")]
     FromUsize { invalid_usize: usize },
+
+    #[error("could not convert u32 {invalid_u32} into a Piece")]
+    FromU32 { invalid_u32: u32 },
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/chess_engine/src/gamestate.rs
+++ b/chess_engine/src/gamestate.rs
@@ -76,6 +76,8 @@ pub struct GamestateBuilder {
 
 // TODO: Revisit question of clones and performance and see if you can improve ergonomics:
 // https://users.rust-lang.org/t/builder-pattern-in-rust-self-vs-mut-self-and-method-vs-associated-function/72892/2
+// currently shouldn't be copying because Board doesn't implement Copy. Which seems reasonable for now
+// That being said, why make the Board reusable if the Gamestate isn't?
 impl GamestateBuilder {
     pub fn new() -> Self {
         GamestateBuilder {
@@ -570,11 +572,12 @@ impl Gamestate {
         fen
     }
 
-    /// Determine if the provided square is currently under attack
-    fn is_square_attacked(&self, square: Square) -> bool {
+    /// Determine if the provided square is currently under attack by the
+    /// provided color
+    fn is_square_attacked(&self, color: Color, square: Square) -> bool {
         // depending on active_color determine which pieces to check
         let mut pieces_to_check: [Piece; 6];
-        match self.active_color {
+        match color {
             Color::White => {
                 pieces_to_check = [
                     Piece::WhitePawn,
@@ -885,7 +888,7 @@ mod tests {
         for rank in Rank::iter() {
             for file in File::iter() {
                 let square = Square::from_file_and_rank(file, rank);
-                output[rank as usize][file as usize] = gamestate.is_square_attacked(square);
+                output[rank as usize][file as usize] = gamestate.is_square_attacked(active_color, square);
             }
         }
 
@@ -991,7 +994,7 @@ mod tests {
         for rank in Rank::iter() {
             for file in File::iter() {
                 let square = Square::from_file_and_rank(file, rank);
-                output[rank as usize][file as usize] = gamestate.is_square_attacked(square);
+                output[rank as usize][file as usize] = gamestate.is_square_attacked(active_color, square);
             }
         }
 
@@ -1093,7 +1096,7 @@ mod tests {
         for rank in Rank::iter() {
             for file in File::iter() {
                 let square = Square::from_file_and_rank(file, rank);
-                output[rank as usize][file as usize] = gamestate.is_square_attacked(square);
+                output[rank as usize][file as usize] = gamestate.is_square_attacked(active_color, square);
             }
         }
 
@@ -1128,7 +1131,7 @@ mod tests {
             for rank in Rank::iter().rev() {
                 for file in File::iter() {
                     let square = Square::from_file_and_rank(file, rank);
-                    match gamestate.is_square_attacked(square) {
+                    match gamestate.is_square_attacked(gamestate.active_color, square) {
                         true => print!("X"),
                         false => print!("-"),
                     }

--- a/chess_engine/src/moves.rs
+++ b/chess_engine/src/moves.rs
@@ -24,8 +24,8 @@ const MOVE_PIECE_PROMOTED_SHIFT: u8 = 20;
 
 /// Information that defines a move is stored in a 32-bit word with the following format
 ///
-/// 0000 0000 0000 0000 0000 0000 0111 1111 START:           0x7F       bits 0-6 represent the Square120 where the move was initiated
-/// 0000 0000 0000 0000 0011 1111 1000 0000 END:             >> 7, 0x7F bits 7-13 represent the Square120 where the move ended
+/// 0000 0000 0000 0000 0000 0000 0111 1111 START:          0x7F       bits 0-6 represent the Square120 where the move was initiated
+/// 0000 0000 0000 0000 0011 1111 1000 0000 END:            >> 7, 0x7F bits 7-13 represent the Square120 where the move ended
 /// 0000 0000 0000 0011 1100 0000 0000 0000 PIECE_CAPTURED: >> 14, 0xF bits 14-17 represent the Piece that was captured (in None then 0)
 /// 0000 0000 0000 0100 0000 0000 0000 0000 EN_PASSANT:     0x40000    bit 18 represents whether or not a capture was an en passant capture
 /// 0000 0000 0000 1000 0000 0000 0000 0000 PAWN_START:     0x80000    bit 19 represents whether the move was a starting pawn move (which can move two spaces)

--- a/chess_engine/src/moves.rs
+++ b/chess_engine/src/moves.rs
@@ -1,24 +1,286 @@
 use std::fmt;
 
+use crate::{
+    error::MoveDeserializeError,
+    piece::Piece,
+    square::{Square, Square64},
+};
+
+//====================== CONSTANTS ============================================
+// any bit representation of a 120 square will occupy at most 7 bits
+const MOVE_SQUARE_MASK: u32 = 0x7F;
+// any bit representation of a piece will occupy at most 4 bits
+const MOVE_PIECE_MASK: u32 = 0xF;
+const MOVE_EN_PASSANT_MASK: u32 = 0x4_0000;
+const MOVE_PAWN_START_MASK: u32 = 0x8_0000;
+const MOVE_CASTLE_MASK: u32 = 0x100_0000;
+
+const MOVE_IS_PROMOTED_MASK: u32 = 0xF00000;
+const MOVE_IS_CAPTURE_MASK: u32 = 0x7c000; // En Passant flag and Piece Captured
+
+const MOVE_END_SHIFT: u8 = 7;
+const MOVE_PIECE_CAPTURED_SHIFT: u8 = 14;
+const MOVE_PIECE_PROMOTED_SHIFT: u8 = 20;
+
+/// Information that defines a move is stored in a 32-bit word with the following format
+///
+/// 0000 0000 0000 0000 0000 0000 0111 1111 START:           0x7F       bits 0-6 represent the Square120 where the move was initiated
+/// 0000 0000 0000 0000 0011 1111 1000 0000 END:             >> 7, 0x7F bits 7-13 represent the Square120 where the move ended
+/// 0000 0000 0000 0011 1100 0000 0000 0000 PIECE_CAPTURED: >> 14, 0xF bits 14-17 represent the Piece that was captured (in None then 0)
+/// 0000 0000 0000 0100 0000 0000 0000 0000 EN_PASSANT:     0x40000    bit 18 represents whether or not a capture was an en passant capture
+/// 0000 0000 0000 1000 0000 0000 0000 0000 PAWN_START:     0x80000    bit 19 represents whether the move was a starting pawn move (which can move two spaces)
+/// 0000 0000 1111 0000 0000 0000 0000 0000 PIECE_PROMOTED: >> 20, 0xF bits 20-23 represent what piece a pawn was promoted to (if None then 0)
+/// 0000 0001 0000 0000 0000 0000 0000 0000 CASTLE:         0x1000000  bit 24 represents whether or not a move was a castling move
+///
+/// bits 25-31 will be unused
+/// IMPORTANT: 000 0000 indicates Square 0 in theory (in practice we should avoid this with the type system) and not absence
+///            0000 indicates absence for Pieces. 0001 indicated White Pawn
+/// NOTE: The number of pieces can fit in 4 bits while the number of 120 squares can fit in 7 bits
 #[derive(Debug, PartialEq, Eq)]
-pub struct Move;
+pub struct Move(u32);
 
 impl Move {
-    pub fn from_uci(uci: &str) -> Self {
-        todo!()
+    /// IMPORTANT: Keep in mind that Piece 0 is a White Pawn but inside move 0
+    /// symbolizes absence.
+    pub fn new(
+        start: Square,
+        end: Square,
+        piece_captured: Option<Piece>,
+        en_passant: bool,
+        pawn_start: bool,
+        piece_promoted: Option<Piece>,
+        castle: bool,
+    ) -> Self {
+        // let mut _move = start as u32;
+        // _move |= (end as u32) << MOVE_END_SHIFT;
+        // _move |= piece_captured.map_or_else(|| 0, |p| (p as u32) + 1) << MOVE_PIECE_CAPTURED_SHIFT;
+        // _move |= (en_passant as u32) * MOVE_EN_PASSANT_MASK;
+        // _move |= (pawn_start as u32) * MOVE_PAWN_START_MASK;
+        // _move |= piece_promoted.map_or_else(|| 0, |p| (p as u32) + 1) << MOVE_PIECE_PROMOTED_SHIFT;
+        // _move |= (castle as u32) * MOVE_CASTLE_MASK;
+
+        Move( (start as u32)
+                | ((end as u32) << MOVE_END_SHIFT)
+
+                | (piece_captured.map_or_else(
+                    || 0,
+                    |p| (p as u32) + 1, // add 1 to make room for 0 to indicate absence
+                ) << MOVE_PIECE_CAPTURED_SHIFT)
+
+                | ((en_passant as u32) * MOVE_EN_PASSANT_MASK)
+                | ((pawn_start as u32) * MOVE_PAWN_START_MASK)
+
+                | (piece_promoted.map_or_else(|| 0, |p| (p as u32) + 1)
+                    << MOVE_PIECE_PROMOTED_SHIFT)
+
+                | ((castle as u32) * MOVE_CASTLE_MASK))
     }
+
+    pub fn get_start(&self) -> Result<Square, MoveDeserializeError> {
+        let start = self.0 & MOVE_SQUARE_MASK;
+        Square::try_from(start).map_err(|_err| MoveDeserializeError::Start {
+            start,
+            _move: self.to_string(),
+        })
+    }
+
+    pub fn get_end(&self) -> Result<Square, MoveDeserializeError> {
+        let end = (self.0 >> MOVE_END_SHIFT) & MOVE_SQUARE_MASK;
+        Square::try_from(end).map_err(|_err| MoveDeserializeError::End {
+            end,
+            _move: self.to_string(),
+        })
+    }
+
+    pub fn get_piece_captured(&self) -> Result<Option<Piece>, MoveDeserializeError> {
+        let piece = (self.0 >> MOVE_PIECE_CAPTURED_SHIFT) & MOVE_PIECE_MASK;
+        match piece {
+            0 => Ok(None),
+            _ => match Piece::try_from(piece - 1) {
+                Ok(piece) => Ok(Some(piece)),
+                Err(_) => Err(MoveDeserializeError::Captured {
+                    piece,
+                    _move: self.to_string(),
+                }),
+            },
+        }
+    }
+
+    pub fn get_en_passant(&self) -> bool {
+        self.0 & MOVE_EN_PASSANT_MASK != 0
+    }
+
+    pub fn get_pawn_start(&self) -> bool {
+        self.0 & MOVE_PAWN_START_MASK != 0
+    }
+
+    pub fn get_piece_promoted(&self) -> Result<Option<Piece>, MoveDeserializeError> {
+        let piece = (self.0 >> MOVE_PIECE_PROMOTED_SHIFT) & MOVE_PIECE_MASK;
+        match piece {
+            0 => Ok(None),
+            _ => match Piece::try_from(piece - 1) {
+                Ok(piece) => Ok(Some(piece)),
+                Err(_) => Err(MoveDeserializeError::Promoted {
+                    piece,
+                    _move: self.to_string(),
+                }),
+            },
+        }
+    }
+
+    pub fn get_castle(&self) -> bool {
+        self.0 & MOVE_CASTLE_MASK != 0
+    }
+
+    pub fn is_capture(&self) -> bool {
+        (self.0 & MOVE_IS_CAPTURE_MASK) != 0
+    }
+
+    pub fn is_promotion(&self) -> bool {
+        (self.0 & MOVE_IS_PROMOTED_MASK) != 0
+    }
+
+    // pub fn from_uci(uci: &str) -> Self {
+    //     todo!()
+    // }
 }
 
 impl fmt::Display for Move {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        todo!()
-        // write!(f, "{}", output_str)
+        let piece_captured = self.get_piece_captured();
+        let piece_promoted = self.get_piece_promoted();
+
+        match self.get_start() {
+            Ok(square) => {
+                writeln!(f, "Start Square: {}", square);
+            }
+            Err(_) => {
+                writeln!(f, "Start Square: Invalid Square");
+            }
+        }
+
+        match self.get_end() {
+            Ok(square) => {
+                writeln!(f, "End Square: {}", square);
+            }
+            Err(_) => {
+                writeln!(f, "End Square: Invalid Square");
+            }
+        }
+
+        match piece_captured {
+            Ok(piece) => match piece {
+                Some(piece) => {
+                    writeln!(f, "Piece Captured: {}", piece);
+                }
+                None => {
+                    writeln!(f, "Piece Captured: None");
+                }
+            },
+            Err(_) => {
+                writeln!(f, "Piece Captured: Invalid Piece");
+            }
+        }
+
+        writeln!(f, "En Passant Capture: {}", self.get_en_passant());
+        writeln!(f, "Pawn Start: {}", self.get_pawn_start());
+
+        match piece_promoted {
+            Ok(piece) => match piece {
+                Some(piece) => {
+                    writeln!(f, "Piece Promoted: {}", piece);
+                }
+                None => {
+                    writeln!(f, "Piece Promoted: None");
+                }
+            },
+            Err(_) => {
+                writeln!(f, "Piece Promoted: Invalid Piece");
+            }
+        }
+
+        writeln!(f, "Castling Move: {}", self.get_castle())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::gamestate::GamestateBuilder;
+
     use super::*;
+
+    //================================ DISPLAY ================================
+    #[test]
+    fn test_move_display_visual() {
+        println!("Game Starting State:");
+
+        let fen_0 = "rnbqkbnr/ppp2ppp/3p4/3Pp3/8/8/PPP1PPPP/RNBQKBNR w KQkq e6 0 3";
+        let mut gamestate = GamestateBuilder::new_with_fen(fen_0).unwrap().build().unwrap();
+        println!("{}", gamestate);
+
+        // D5 0x40 E6 0x4B
+        println!("D5E6 White Pawn captures Black Pawn via En Passant");
+        #[allow(clippy::unusual_byte_groupings)]
+        //                        unused      cstl prom ps ep capt end     start
+        let move_1 = Move(0b_00000000000_0____0000_0__1__0111_1001011_1000000);
+        println!("{}", move_1);
+
+        let fen_1 = "rnbqkbnr/ppp2ppp/3pP3/8/8/8/PPP1PPPP/RNBQKBNR b KQkq - 0 3";
+        gamestate = GamestateBuilder::new_with_fen(fen_1).unwrap().build().unwrap();
+        println!("{}", gamestate);
+
+        
+        // C8 0x5D E6 0x4B
+        println!("C8E6 Black Bishop captures White Pawn");
+        #[allow(clippy::unusual_byte_groupings)]
+        //                        unused      cstl prom ps ep capt end     start
+        let move_2 = Move(0b_00000000000_0____0000_0__0__0001_1001011_1011101);
+        println!("{}", move_2);
+
+        let fen_2 = "rn1qkbnr/ppp2ppp/3pb3/8/8/8/PPP1PPPP/RNBQKBNR w KQkq - 0 4";
+        gamestate = GamestateBuilder::new_with_fen(fen_2).unwrap().build().unwrap();
+        println!("{}", gamestate);
+
+
+    }
+
+    //================================= BUILD =================================
+    #[test]
+    fn test_move_build_en_passant_capture() {
+        // rnbqkbnr/ppp2ppp/3p4/3Pp3/8/8/PPP1PPPP/RNBQKBNR  WP captures bp via ep E6
+        let start = Square::D5;
+        let end = Square::E6;
+
+        let piece_captured = Some(Piece::BlackPawn);
+
+        let en_passant = true;
+        let pawn_start = false;
+
+        let piece_promoted = None;
+        let castle = false;
+
+        let output = Move::new(
+            start,
+            end,
+            piece_captured,
+            en_passant,
+            pawn_start,
+            piece_promoted,
+            castle,
+        );
+
+        // start is 0x40
+        // end is 0x4B
+        // captured black pawn is 6 so stored as 7 to make room for 0 to be absence
+        // piece promoted None so 0
+        let expected = Move(
+            #[allow(clippy::unusual_byte_groupings)]
+            // unused      cstl prom ps ep capt end     start
+            0b_00000000000_0____0000_0__1__0111_1001011_1000000,
+        );
+
+        assert_eq!(output, expected)
+    }
 
     // #[test]
     // fn test_from_uci() {

--- a/chess_engine/src/moves.rs
+++ b/chess_engine/src/moves.rs
@@ -36,7 +36,7 @@ const MOVE_PIECE_PROMOTED_SHIFT: u8 = 20;
 /// IMPORTANT: 000 0000 indicates Square 0 in theory (in practice we should avoid this with the type system) and not absence
 ///            0000 indicates absence for Pieces. 0001 indicated White Pawn
 /// NOTE: The number of pieces can fit in 4 bits while the number of 120 squares can fit in 7 bits
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Move(u32);
 
 impl Move {

--- a/chess_engine/src/piece.rs
+++ b/chess_engine/src/piece.rs
@@ -329,6 +329,28 @@ impl TryFrom<usize> for Piece {
     }
 }
 
+impl TryFrom<u32> for Piece {
+    type Error = PieceConversionError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Piece::WhitePawn),
+            1 => Ok(Piece::WhiteKnight),
+            2 => Ok(Piece::WhiteBishop),
+            3 => Ok(Piece::WhiteRook),
+            4 => Ok(Piece::WhiteQueen),
+            5 => Ok(Piece::WhiteKing),
+            6 => Ok(Piece::BlackPawn),
+            7 => Ok(Piece::BlackKnight),
+            8 => Ok(Piece::BlackBishop),
+            9 => Ok(Piece::BlackRook),
+            10 => Ok(Piece::BlackQueen),
+            11 => Ok(Piece::BlackKing),
+            _ => Err(PieceConversionError::FromU32 { invalid_u32: value }),
+        }
+    }
+}
+
 impl fmt::Display for Piece {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/chess_engine/src/square.rs
+++ b/chess_engine/src/square.rs
@@ -103,7 +103,6 @@ impl TryFrom<usize> for Square64 {
             .find(|s| *s as usize == value)
             .ok_or(Square64ConversionError::FromUsize { index: value })
     }
-
 }
 
 impl Square64 {


### PR DESCRIPTION
Revisiting the builder refactor revealed a bunch of tradeoffs and extra considerations (which style of piping to use for builder setters has an impact on the ergonomics and reusability of the builder). It's not completely clear at this point what the best way to set it up will be so for now, Board is using &mut self style and Gamestate is using mut self and explicitly cloning Board, history, and Zobrist since they all include Vecs that are on the heap and can't derive Copy. This should be revisited down the line and tested for performance considerations.

Also sets up Move struct which just wraps a u32 and packs Start Square, End Square, Piece Captured, En Passant Square, Pawn Start, Piece Promoted, and Castle information into the bits. One slightly tricky decision that had to made there has to do with whether 0s represent the absence of pieces/squares. In the case of Squares 000 0000 represents Square 0 which is invalid but should never show up if we do our job properly. Piece 0000 will represent absence of  a piece (such as when a move occurs where no piece is captured), but this necessitates some index incrementing because our Piece enum allows us to convert from a value of 0 to a White Pawn.